### PR TITLE
fix: null apply for outputs

### DIFF
--- a/configs/evaluation/classification.yaml
+++ b/configs/evaluation/classification.yaml
@@ -4,7 +4,7 @@ apply:
     _target_: src.utils.hydra.partial
     _partial_: src.evaluation.classification.get_preds
   # takes (flattened_step_outputs: dict) where list of step_outputs are flattened
-  step_outputs: null 
+  step_outputs: null
 
 # Which keys/attributes are supposed to be collected from `outputs` and `batch`
 step_outputs:

--- a/configs/experiment/mnli_tinybert.yaml
+++ b/configs/experiment/mnli_tinybert.yaml
@@ -9,3 +9,4 @@ defaults:
 module:
   model:
     pretrained_model_name_or_path: "prajjwal1/bert-tiny"
+    num_labels: 3

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -200,17 +200,18 @@ The evaluation mixin diminishes the boilerplate when writing custom evaluation l
 The configuration separates on a high level into:
 
 * **apply**: transformation functions applied to `batch`, `outputs`, and `step_outputs`
-* **step_outputs**: what keys of (default: complete `batch` and `outputs`)
+* **step_outputs**: what keys of `step_outputs` to keep for `eval_epoch_end` (default: complete `batch` and `outputs`)
 * **metric**: configure how to instantiate and compute your metric
 
 .. code-block:: yaml
 
     # apply transformation function 
     apply:
-      batch: null
-      outputs:   
+      batch: null # a function that takes (batch)
+      outputs: # a function that takes (outputs, batch)
         _target_: src.utils.hydra.partial
         _partial_: src.evaluation.classification.get_preds
+      step_outputs: null # a function that takes (step_outputs)
 
       step_outputs: null  # on flattened outputs of what's collected from steps
 


### PR DESCRIPTION
Closes #1 

* Only applies a transformation function on `{batch, outputs, step_outputs}` if instantiation results in a `callable`
* Improves documentation of `customization` to include function signatures of `apply` functions

Many thanks for reporting @MinhDucBui :) Does this fix the issue?

You can use https://github.com/cli/cli to check out the PR like so

`gh pr checkout 2`

E: realized this won't work if an `apply` key is not defined, will fix in the morning